### PR TITLE
Avoid the cost of reflection in tight loops

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,5 @@
   ;; add per WARNING: JVM argument TieredStopAtLevel=1 is active...
   :jvm-opts ^:replace []
   ;; add leipzig for use in examples
-  :profiles {:dev {:dependencies [[leipzig "0.6.0" :exclusions [[overtone]]]]}})
+  :profiles {:dev {:dependencies [[leipzig "0.6.0" :exclusions [[overtone]]]]
+                   :global-vars {*warn-on-reflection* true *assert* false}}})


### PR DESCRIPTION
## What? 

Improve the performance of the draw fn by avoiding the cost of reflection by using type hints.
Might only be a little bump in performance but worthy of saving were possible.

I've also turned reflection warnings on, so its easier to spot reflection costs within highly repeatable code chunks.